### PR TITLE
chore: Add a local development server as a devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "> a small interactive tool for understanding node lts versions",
   "main": "index.js",
   "scripts": {
+    "start": "live-server .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -20,5 +21,8 @@
   "dependencies": {
     "bootstrap": "^3.3.6",
     "jquery": "^2.1.4"
+  },
+  "devDependencies": {
+    "live-server": "^0.8.2"
   }
 }


### PR DESCRIPTION
This makes it easier/quicker to see changes, but you may not want to add devDeps to keep the initial clone/install quick. I also took a very large liberty in binding it to the `start` script, so lmk if that's not the road you want to go down and I'm happy to adjust.
